### PR TITLE
fix flaky test org.aim42.htmlsanitycheck.check.BrokenCrossReferencesCheckerTest.testTwoBrokenLinks

### DIFF
--- a/src/main/groovy/org/aim42/htmlsanitycheck/check/BrokenCrossReferencesChecker.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/check/BrokenCrossReferencesChecker.groovy
@@ -38,7 +38,7 @@ class BrokenCrossReferencesChecker extends SuggestingChecker {
     protected SingleCheckResults check(final HtmlPage pageToCheck) {
         //get list of all a-tags "<a href=..." in html file
         hrefList = pageToCheck.getAllHrefStrings()
-        hrefSet = hrefList.toSet()
+        hrefSet = hrefList.toSet().sort()
 
         // get list of all id="XYZ"
         listOfIds = pageToCheck.getAllIdStrings()

--- a/src/test/groovy/org/aim42/htmlsanitycheck/check/BrokenCrossReferencesCheckerTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/check/BrokenCrossReferencesCheckerTest.groovy
@@ -101,14 +101,13 @@ class BrokenCrossReferencesCheckerTest extends GroovyTestCase {
 
         // first finding: aim42 link missing
         String actual = collector.findings.first()
-        String expected = "link target \"arc42\" missing"
+        String expected = "link target \"aim42\" missing"
         String message = "expected $expected"
-
         assertEquals(message, expected, actual)
 
         // second finding: arc42 link missing
         actual = collector.findings[1]
-        expected = "link target \"aim42\" missing"
+        expected = "link target \"arc42\" missing"
         assertEquals(message, expected, actual)
     }
 


### PR DESCRIPTION
## Problem

The test `org.aim42.htmlsanitycheck.check.BrokenCrossReferencesCheckerTest.testTwoBrokenLinks` asserts the finding of the _SingleCheckResults_. These findings are stored in a Set. But the order, in which the two given findings are returned by the set, is not deterministic. The test expects the values to be in certain order. This leads to a flaky test. 


https://github.com/hofi1/htmlSanityCheck/blob/d6d128eeced62e867bd5c804eef72589b3af7bb4/src/test/groovy/org/aim42/htmlsanitycheck/check/BrokenCrossReferencesCheckerTest.groovy#L91-L112


This problem was found by the [NonDex](https://github.com/TestingResearchIllinois/NonDex) Engine.

## Solution
Sort the set, to make sure, it is returned in predefined order. 

https://github.com/hofi1/htmlSanityCheck/blob/d6d128eeced62e867bd5c804eef72589b3af7bb4/src/main/groovy/org/aim42/htmlsanitycheck/check/BrokenCrossReferencesChecker.groovy#L41

Furthermore, the order of the expected elements in the test had to be changed. 


## Reproduce
To reproduce follow the steps:

1. `./gradlew build -x test`
2. Add the following text to the top of the build.gradle file in $PROJ_DIR.
```shell
buildscript {
    repositories {
      maven {
        url = uri('https://plugins.gradle.org/m2/')
      }
    }
    dependencies {
      classpath('edu.illinois:plugin:2.1.1')
    }
}
``` 
3. Add the following line to the end of the build.gradle file in $PROJ_DIR.
```shell
apply plugin: 'edu.illinois.nondex'
``` 
4. Run
```shell
./gradlew --info nondexTest --tests=org.aim42.htmlsanitycheck.check.BrokenCrossReferencesCheckerTest.testTwoBrokenLinks --nondexRuns=50
``` 